### PR TITLE
feat: add cursor style to indicate image is zoomable

### DIFF
--- a/src/components/photoswipe.vue
+++ b/src/components/photoswipe.vue
@@ -214,4 +214,10 @@ export default class Photoswipe extends Vue {
 <style>
 @import '~photoswipe/dist/photoswipe.css';
 @import '~photoswipe/dist/default-skin/default-skin.css';
+
+.pswipe-gallery img,
+.pswipe-gallery [data-pswp-src] { /* For usage with <div> */
+  cursor: pointer; /* Fallback for unsupported browsers */
+  cursor: zoom-in;
+}
 </style>

--- a/src/components/photoswipe.vue
+++ b/src/components/photoswipe.vue
@@ -215,9 +215,8 @@ export default class Photoswipe extends Vue {
 @import '~photoswipe/dist/photoswipe.css';
 @import '~photoswipe/dist/default-skin/default-skin.css';
 
-.pswipe-gallery img,
-.pswipe-gallery [data-pswp-src] { /* For usage with <div> */
-  cursor: pointer; /* Fallback for unsupported browsers */
-  cursor: zoom-in;
+.pswipe-gallery [data-pswp-src] {
+    cursor: pointer; /* Fallback for unsupported browsers */
+    cursor: zoom-in;
 }
 </style>


### PR DESCRIPTION
This style is unrelated to PhotoSwipe UI so I didn't put it in `pswpUI.vue`. Feel free to move it elsewhere.